### PR TITLE
Add search button to songs list to collapse mobile keyboard

### DIFF
--- a/korczak-xyz/src/components/SongsListContent.astro
+++ b/korczak-xyz/src/components/SongsListContent.astro
@@ -32,7 +32,8 @@ const years = Math.max(1, Math.round((now.getTime() - oldestDate.getTime()) / (3
 ---
 
 <PageContent title={t('Songs')}>
-  <div class="search-container">
+  <form class="search-container" id="song-search-form">
+    <button type="submit" id="search-submit" class="search-submit" aria-label={t('Search')}>🔍</button>
     <input
       type="text"
       id="song-search"
@@ -40,7 +41,7 @@ const years = Math.max(1, Math.round((now.getTime() - oldestDate.getTime()) / (3
       class="song-search-input"
     />
     <button type="button" id="search-clear" class="search-clear" aria-label="Clear search">×</button>
-  </div>
+  </form>
   <p class="songs-summary">
     {songCount} {t('songs added over')} {years} {years === 1 ? t('year') : t('years')}
   </p>
@@ -75,7 +76,25 @@ const years = Math.max(1, Math.round((now.getTime() - oldestDate.getTime()) / (3
     font-size: 1.1rem;
     background: var(--retro-white);
     border: 2px inset var(--retro-dark-gray);
-    padding: 8px 30px 8px 15px;
+    padding: 8px 30px 8px 40px;
+    color: var(--retro-black);
+  }
+
+  .search-submit {
+    position: absolute;
+    left: 8px;
+    top: 50%;
+    transform: translateY(-50%);
+    background: none;
+    border: none;
+    font-size: 1.1rem;
+    line-height: 1;
+    color: var(--retro-dark-gray);
+    cursor: pointer;
+    padding: 0 4px;
+  }
+
+  .search-submit:hover {
     color: var(--retro-black);
   }
 
@@ -118,6 +137,7 @@ const years = Math.max(1, Math.round((now.getTime() - oldestDate.getTime()) / (3
 </style>
 
 <script>
+  const searchForm = document.getElementById('song-search-form') as HTMLFormElement;
   const searchInput = document.getElementById('song-search') as HTMLInputElement;
   const clearBtn = document.getElementById('search-clear');
   const songsList = document.getElementById('songs-list');
@@ -164,5 +184,10 @@ const years = Math.max(1, Math.round((now.getTime() - oldestDate.getTime()) / (3
       searchInput.dispatchEvent(new Event('input'));
       searchInput.focus();
     }
+  });
+
+  searchForm?.addEventListener('submit', (e) => {
+    e.preventDefault();
+    searchInput?.blur();
   });
 </script>

--- a/korczak-xyz/src/i18n/index.ts
+++ b/korczak-xyz/src/i18n/index.ts
@@ -72,6 +72,7 @@ export const ui = {
     // Songs
     'Date added': 'Date added',
     'Search songs...': 'Search songs...',
+    'Search': 'Search',
     'No songs found': 'No songs found',
     'songs added over': 'songs added over',
     'year': 'year',
@@ -305,6 +306,7 @@ export const ui = {
     // Songs
     'Date added': 'Dodano',
     'Search songs...': 'Szukaj...',
+    'Search': 'Szukaj',
     'No songs found': 'Nie znaleziono piosenek',
     'songs added over': 'piosenek dodanych przez',
     'year': 'rok',


### PR DESCRIPTION
## Summary
- Wrap the songs search input in a form with a search (🔍) submit button
- Submitting (tap or Enter) blurs the input, collapsing the mobile keyboard so users can see filtered results, without a page reload
- Live filtering on input remains unchanged
- Add `Search` i18n key (EN/PL) for the button's aria-label

## Test plan
- [x] `npm run build` succeeds and the search button renders correctly in the built songs page


---
_Generated by [Claude Code](https://claude.ai/code/session_01R5s2rgecQfMzUQ1qn8ypY6)_